### PR TITLE
Update README.md

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -18,7 +18,7 @@ kubectl create ns datadog
 - Create the secret using the file created ealier.
 
 ```shell
-kubectl create secret generic datadog-keys --from-env-file=secrets.txt
+kubectl create secret generic datadog-keys -n datadog --from-env-file=secrets.txt
 ```
 
 - Download the [values file](helm) for your Kubernetes flavour. Update values like `datadog.clusterName` and `DD_ENV`. If creating a secret with a different name in the previous step, update `datadog.apiKeyExistingSecret`.


### PR DESCRIPTION
Just ran through these steps on EKS. I was getting stuck on a config error for the agents, cluster-agent was crashlooping because of it. When I described the pods the error indicated the pod was not able to detect the existing k8s secret datadog-keys.

After some head scratching, I finally figured it out and the issue is because the secret is not tied to the datadog namespace.